### PR TITLE
Remove is_comments_popup() from query_monitor_conditionals

### DIFF
--- a/collectors/conditionals.php
+++ b/collectors/conditionals.php
@@ -33,7 +33,6 @@ class QM_Collector_Conditionals extends QM_Collector {
 			'is_blog_admin',
 			'is_category',
 			'is_comment_feed',
-			'is_comments_popup',
 			'is_customize_preview',
 			'is_date',
 			'is_day',


### PR DESCRIPTION
It is deprecated as of https://core.trac.wordpress.org/changeset/35848

The internet broke. (Deprecation notices started appearing at `shutdown` in Query Monitor and corrupted JSON Ajax responses.)
